### PR TITLE
Include non-hyperlink URLs as part of search query

### DIFF
--- a/scripts/retrieve-data.js
+++ b/scripts/retrieve-data.js
@@ -20,13 +20,13 @@ function RetrieveDataAboutUrl(info, callback) {
 //returns a string that should yield the best results when used as a reddit querry
 function DeconstructURLForSearchTerms(info) {
     let url = info.url;
-    var searchTerm = `url:"${url.hostname+url.pathname}"`;
+    var searchTerm = `url:"${url.hostname+url.pathname}" OR "${url.hostname+url.pathname}"`;
     let domainData = GetDomainData(url.host);
     if(domainData)
     {
         let paramValue = url.searchParams.get(domainData.parameter_name);
         if (paramValue != undefined)
-            searchTerm = `url:"${paramValue}"`;
+            searchTerm = `url:"${paramValue}" OR "${paramValue}"`;
     }
     switch (url.hostname) {
         case "reddit.com":


### PR DESCRIPTION
Extension is only finding posts where the post has attached the URL. It isn't finding comments with URLs, etc. 

This change should fix the issue.

Before:
![image](https://github.com/user-attachments/assets/06ef81ba-2b91-41b3-99cf-f5ff486c10d7)

After:
![image](https://github.com/user-attachments/assets/74f0f6a6-85bb-4c26-97fc-75821a63e533)
